### PR TITLE
add responsive canvas resize + remove unused variables

### DIFF
--- a/wiv.js
+++ b/wiv.js
@@ -13,7 +13,6 @@ function initWiv(wiv) {
   canvas.style.position = "absolute";
   canvas.style.pointerEvents ="none";
   wiv.insertBefore(canvas, wiv.firstChild);
-  console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"beforeinit")
 }
 
 /**
@@ -29,7 +28,6 @@ function initWivs() {
       canvas.height = wivs[i+1].offsetHeight;
       canvas.width = wivs[i+1].offsetWidth;
     }
-    console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"ininit")
   }
 }
 
@@ -117,5 +115,4 @@ function animateLines() {
 }
 //initial wivs and call initial frame render
 initWivs();
-console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"afterinit")
 window.requestAnimationFrame(animateLines);

--- a/wiv.js
+++ b/wiv.js
@@ -22,12 +22,12 @@ function initWivs() {
   var wivs = document.getElementsByClassName("wiv");
   for (i = wivs.length - 1; i >= 0; i--) {
     initWiv(wivs[i]);
-    // resetting the previous' wiv canvas size for responsive views
-    if (i < wivs.length-1) {
-      var canvas = document.getElementsByTagName("canvas")[i+1]
-      canvas.height = wivs[i+1].offsetHeight;
-      canvas.width = wivs[i+1].offsetWidth;
-    }
+  }
+  // reset the previous' wiv canvas size for responsive views
+  for (i = 0; i < wivs.length; i++) {
+    var canvas = document.getElementsByTagName("canvas")[i];
+      canvas.height = wivs[i].offsetHeight;
+      canvas.width = wivs[i].offsetWidth;
   }
 }
 

--- a/wiv.js
+++ b/wiv.js
@@ -1,9 +1,4 @@
 function initWiv(wiv) {
-  let left = wiv.offsetLeft;
-  let top = wiv.offsetTop;
-  let height = parseFloat(wiv.dataset.wivHeight);
-  let penRadius = parseFloat(wiv.dataset.wivThickness)
-
   //style wiv elements 
   wiv.style.display = "inline-block";
   wiv.style.borderRadius = parseFloat(wiv.dataset.wivHeight) + "px";
@@ -18,6 +13,7 @@ function initWiv(wiv) {
   canvas.style.position = "absolute";
   canvas.style.pointerEvents ="none";
   wiv.insertBefore(canvas, wiv.firstChild);
+  console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"beforeinit")
 }
 
 /**
@@ -27,6 +23,13 @@ function initWivs() {
   var wivs = document.getElementsByClassName("wiv");
   for (i = wivs.length - 1; i >= 0; i--) {
     initWiv(wivs[i]);
+    // resetting the previous' wiv canvas size for responsive views
+    if (i < wivs.length-1) {
+      var canvas = document.getElementsByTagName("canvas")[i+1]
+      canvas.height = wivs[i+1].offsetHeight;
+      canvas.width = wivs[i+1].offsetWidth;
+    }
+    console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"ininit")
   }
 }
 
@@ -114,4 +117,5 @@ function animateLines() {
 }
 //initial wivs and call initial frame render
 initWivs();
+console.log(document.getElementsByClassName("wiv")[1].offsetHeight,"afterinit")
 window.requestAnimationFrame(animateLines);


### PR DESCRIPTION
I've added a fix for responsive views where wiv.offsetHeight and wiv.offsetWidth are changed after the next wiv's init. In that case, the respective canvas needs to be resized. 

You can see the behavior here when in responsive/mobile view: [old version](http://zlatkovsky.cz/index_wiv_old.html), [fixed version](http://zlatkovsky.cz/index_wiv.html).

I've also removed unused variables in initWiv().

Merry Christmas!