### PR TITLE
Rollup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+!dist/wiv.js
+node_modules

--- a/dist/wiv.js
+++ b/dist/wiv.js
@@ -1,0 +1,187 @@
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+  typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  (global = global || self, factory(global.wiv = {}));
+}(this, function (exports) { 'use strict';
+
+  function wiv(params) {
+    params = params || {};
+    let isMobile = false;
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+      isMobile = true;
+    }
+    let mobileCompressionFactor = validatePositiveInteger(params.mobileCompressionFactor, 2);
+    let globalCompressionFactor = validatePositiveInteger(params.globalCompressionFactor);
+    if (isMobile) {
+      globalCompressionFactor *= mobileCompressionFactor;
+    }
+    let cache = {};
+    let wivCounter = 0;
+
+    const speeds = {
+      "slow": .15,
+      "standard": .55,
+      "fast": 1.55,
+      "faster": 3.15,
+      "turbo": 6.15
+    };
+
+    function initWiv(wiv) {
+      //style wiv elements
+      wiv.style.display = "inline-block";
+      wiv.style.borderRadius = parseFloat(wiv.dataset.wivHeight) + "px";
+      wiv.children[0].style.padding = (parseFloat(wiv.dataset.wivHeight) * 4) + "px";
+
+      //insert wiv canvas element
+      let canvas = document.createElement('canvas');
+      canvas.id = "wiv-curves-" + wivCounter++;
+      canvas.className = "wiv-curves";
+      canvas.width = wiv.offsetWidth;
+      canvas.height = wiv.offsetHeight;
+      canvas.style.zIndex = 16;
+      canvas.style.position = "absolute";
+      canvas.style.pointerEvents = "none";
+      wiv.insertBefore(canvas, wiv.firstChild);
+
+
+      let color = wiv.dataset.wivColor !== undefined ? wiv.dataset.wivColor : "#FF0000";
+      let speed = speeds[wiv.dataset.wivSpeed] || parseFloat(wiv.dataset.wivSpeed) || speeds.standard;
+      let height = parseFloat(wiv.dataset.wivHeight);
+      let tightness = parseFloat(wiv.dataset.wivTightness);
+      let thickness = parseFloat(wiv.dataset.wivThickness);
+      let increment = validatePositiveInteger(wiv.dataset.wivCompressionFactor);
+      increment *= globalCompressionFactor;
+
+      let ctx = canvas.getContext("2d");
+      ctx.strokeStyle = color;
+      ctx.lineWidth = thickness;
+
+      cache[canvas.id] = {
+        'speed': speed,
+        'height': height,
+        'tightness': tightness,
+        'thickness': thickness,
+        'increment': increment,
+        'color': color,
+        'context': ctx,
+        'count': 0
+      };
+
+    }
+
+    /**
+     * Initialize all wiv elements. Going in reverse makes sure heights adjust to children wivs.
+     */
+    function initWivs() {
+      let wivs = document.getElementsByClassName("wiv");
+      for (let i = wivs.length - 1; i >= 0; i--) {
+        initWiv(wivs[i]);
+      }
+      // reset the previous' wiv canvas size for responsive views
+      for (let i = 0; i < wivs.length; i++) {
+        let canvas = document.getElementsByTagName("canvas")[i];
+        canvas.height = wivs[i].offsetHeight;
+        canvas.width = wivs[i].offsetWidth;
+      }
+      window.requestAnimationFrame(processWivs);
+    }
+
+    function processWivs() {
+      let wivCurves = document.getElementsByClassName("wiv-curves");
+
+      for (let wivCurve of wivCurves) {
+        let curveCache = cache[wivCurve.id];
+        let speed = curveCache.speed;
+        let height = curveCache.height;
+        let tightness = curveCache.tightness;
+        let thickness = curveCache.thickness;
+        let increment = curveCache.increment;
+        let count = curveCache.count;
+        let color = curveCache.color;
+        let ctx = curveCache.context;
+        curveCache.count = drawLines(wivCurve, speed, height, tightness, thickness, increment, count, color, ctx);
+      }
+      // reanimate
+      window.requestAnimationFrame(processWivs);
+    }
+
+    /**
+    Represents the logic to draw a single frame. Animates all wivs
+    */
+    function drawLines(canvas, speed, height, tightness, thickness, increment, frame, color, ctx = null) {
+      if(ctx === null){
+        ctx = canvas.getContext("2d");
+      }
+      ctx.beginPath();
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      let x = height * 2 + thickness;
+      let y = height - Math.sin(((x - frame) * tightness) * Math.PI / 180) * height + thickness;
+
+      //draw top
+      for (x = height * 3; x <= canvas.width - (height * 3); x += increment) {
+        y = height - Math.sin(((x - frame) * tightness) * Math.PI / 180) * height + thickness;
+        ctx.lineTo(x, y);
+      }
+
+      //draw right
+      for (; y <= canvas.height - (height * 3); y += increment) {
+        x = (canvas.width - height * 3) + height - Math.cos(((y - frame) * tightness) * Math.PI / 180) * height + thickness;
+        ctx.lineTo(x, y);
+      }
+
+      //draw bottom
+      for (; x >= (height * 3); x -= increment) {
+        y = (canvas.height - height * 3) + height - Math.sin(((x - frame) * tightness) * Math.PI / 180) * height + thickness;
+        ctx.lineTo(x, y);
+      }
+
+      //draw left
+      for (; y >= (height * 2) + thickness; y -= increment) {
+        x = height - Math.cos(((y - frame) * tightness) * Math.PI / 180) * height + thickness;
+        ctx.lineTo(x, y);
+      }
+
+      //draw top
+      for (; x <= (height * 3) + increment; x += increment) {
+        y = height - Math.sin(((x - frame) * tightness) * Math.PI / 180) * height + thickness;
+        ctx.lineTo(x, y);
+      }
+
+      //pull color from dataset
+      ctx.strokeStyle = color;
+      ctx.lineWidth = thickness;
+
+      ctx.stroke();
+
+      //current frame is tracked on per wiv basis. This is to help with speed calculations
+      if (frame > 100000) {
+        frame = 0;
+      }
+
+      frame = (frame ? frame : 0) + speed;
+      return frame;
+    }
+
+    function validatePositiveInteger(value, defaultVal) {
+      defaultVal = defaultVal || 1;
+      value = parseInt(value);
+      if (!value || value < 1) {
+        value = defaultVal;
+      }
+      return value;
+    }
+
+    return {
+      initWivs,
+      drawLines,
+      defaultSpeeds: speeds,
+    }
+  }
+
+  exports.wiv = wiv;
+
+  Object.defineProperty(exports, '__esModule', { value: true });
+
+}));
+//# sourceMappingURL=wiv.js.map

--- a/index.html
+++ b/index.html
@@ -156,10 +156,10 @@
       </div>
     </div>
   </div>
-  <script src="wiv.js"></script>
+  <script src="dist/wiv.js"></script>
   <script>
     //initial wivs and call initial frame render
-    let w = wiv();
+    let w = wiv.wiv();
     w.initWivs();
   </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "wiv.js",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.0.tgz",
+      "integrity": "sha512-LV6Qz+RkuDAfxr9YopU4k5o5P/QA7YNq9xi2Ug2IqOmhPt9sAm89vh3SkNtFok3bqZHX54eMJZ8F68HPejgqtw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*",
+        "acorn": "^6.0.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "wiv.js",
   "version": "0.0.1",
   "description": "A library for a more wiggly div",
-  "main": "wiv.js",
+  "main": "dist/wiv.cjs.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "rm -r dist",
+    "build": "npm run clean && rollup -c",
+    "watch": "rollup -c -w",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -24,5 +28,11 @@
   "bugs": {
     "url": "https://github.com/jjkaufman/wiv.js/issues"
   },
-  "homepage": "https://github.com/jjkaufman/wiv.js#readme"
+  "homepage": "https://github.com/jjkaufman/wiv.js#readme",
+  "devDependencies": {
+    "rollup": "^1.0.0"
+  },
+  "files": [
+    "dist"
+  ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+const pkg = require('./package.json')
+module.exports = {
+  input: 'wiv.js',
+  output: [
+    {
+      file: pkg.main,
+      format: 'cjs',
+      sourcemap: true
+    },
+    {
+      file: 'dist/wiv.js',
+      format: 'umd',
+      sourcemap: true,
+      name: 'wiv'
+    }
+  ],
+}

--- a/wiv.js
+++ b/wiv.js
@@ -68,11 +68,11 @@ function wiv(params) {
    */
   function initWivs() {
     let wivs = document.getElementsByClassName("wiv");
-    for (i = wivs.length - 1; i >= 0; i--) {
+    for (let i = wivs.length - 1; i >= 0; i--) {
       initWiv(wivs[i]);
     }
     // reset the previous' wiv canvas size for responsive views
-    for (i = 0; i < wivs.length; i++) {
+    for (let i = 0; i < wivs.length; i++) {
       let canvas = document.getElementsByTagName("canvas")[i];
       canvas.height = wivs[i].offsetHeight;
       canvas.width = wivs[i].offsetWidth;
@@ -168,8 +168,9 @@ function wiv(params) {
 
   return {
     initWivs,
-    drawLines
+    drawLines,
+    defaultSpeeds: speeds,
   }
 }
 
-// export { wiv }
+export { wiv }


### PR DESCRIPTION
Rollup gives us better packaging options.  Publish the CommonJS file to npm for installation, and export a UMD build for browser usage

Could unify on UMD but it's a bit uglier than the CJS style.

 Not 100% sure on how to properly handle browser usage.  For now, it builds in dist/wiv.js (effectively just removes the `export`), but we can probably rig up something for GH Pages involving the actual built output instead of having it just sit in the repo.

`npm publish` and you're off to the races otherwise